### PR TITLE
ch16158: Update Submarine documentation and Swagger docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+Clubhouse: [ch1234](https://app.clubhouse.io/disco/story/1234/do-something)
+
+### Description
+A brief overview of the work done. Be sure to provide some context to the issue/feature, so that the reviewer can jump right on in and review your sweet, sweet code. 
+
+Highlight any interesting design decisions that you may have taken.
+
+### Notes
+* A bulleted list of any secondary information that you feel would be useful to the reviewer.
+* Gotchas, new dependencies, unusual data migrations, etc., would all live here.
+
+### Checklist
+- [ ] Checked that this PR is referencing the correct base.
+- [ ] Logged all time in Clockify.

--- a/build/customer-api.md
+++ b/build/customer-api.md
@@ -470,6 +470,12 @@ ID of the currently logged in customer.
 ID of the subscription to update.
 {% endapi-method-parameter %}
 {% endapi-method-path-parameters %}
+
+{% api-method-body-parameters %}
+{% api-method-parameter name="subscription" type="object" required=true %}
+An object containing the updates to apply.
+{% endapi-method-parameter %}
+{% endapi-method-body-parameters %}
 {% endapi-method-request %}
 
 {% api-method-response %}
@@ -480,6 +486,61 @@ ID of the subscription to update.
 
 ```text
 
+```
+{% endapi-method-response-example %}
+{% endapi-method-response %}
+{% endapi-method-spec %}
+{% endapi-method %}
+
+{% api-method method="post" host="" path="/api/v1/customers/{{ customer\_id }}/subscriptions/bulk\_update.json" %}
+{% api-method-summary %}
+Bulk update existing subscriptions
+{% endapi-method-summary %}
+
+{% api-method-description %}
+Update multiple existing subscriptions for the current customer in a single API call. Currently, only the payment method linked to the subscription can be updated in bulk.
+{% endapi-method-description %}
+
+{% api-method-spec %}
+{% api-method-request %}
+{% api-method-path-parameters %}
+{% api-method-parameter name="customer\_id" type="integer" required=true %}
+ID of the currently logged in customer.
+{% endapi-method-parameter %}
+{% endapi-method-path-parameters %}
+
+{% api-method-body-parameters %}
+{% api-method-parameter name="bulk\_update" type="object" required=true %}
+An object containing details of the bulk update to be performed. The `bulk_update` object has two attributes: `subscription_ids`, a list of the subscriptions that should be updated, and `subscription`, which is an object containing the updates to apply.
+{% endapi-method-parameter %}
+{% endapi-method-body-parameters %}
+{% endapi-method-request %}
+
+{% api-method-response %}
+{% api-method-response-example httpCode=200 %}
+{% api-method-response-example-description %}
+
+{% endapi-method-response-example-description %}
+
+```
+{
+  "data": {
+    "id": "816b5f28-0a79-42a0-a69e-5ae37d06821c",
+    "type": "bulk_update_subscriptions_result",
+    "attributes": {
+      "successes": {
+        "data": [
+          ...a list of updated subscription objects...
+        ]
+      },
+      "failures": {
+        "data": [
+          ...a list of subscription objects that failed to update...
+        ]
+      }
+    }
+  }  
+}        
 ```
 {% endapi-method-response-example %}
 {% endapi-method-response %}


### PR DESCRIPTION
Clubhouse: [ch16158](https://app.clubhouse.io/disco/story/16158)

### Description
Adds documentation for the new bulk update subscriptions customer API endpoint.

### Notes
* See the PR for the corresponding code change, including the update to the Swagger documentation, [here](https://github.com/discolabs/submarine/pull/426).

### Checklist
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.